### PR TITLE
Update commons-text to 1.10.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-text</artifactId>
-      <version>1.8</version>
+      <version>1.10.0</version>
     </dependency>
 
     <!-- https://mvnrepository.com/artifact/com.squareup.okhttp3/okhttp -->


### PR DESCRIPTION
Downstream of https://github.com/jenkinsci/commons-text-api-plugin/pull/13#issuecomment-1278814319

It's probably worth to cut a release, to silence security scanners and reduce the amount of Jira issues.

cc @luodongjia 